### PR TITLE
Feature ETP-1977: Added Opentelemetry support.

### DIFF
--- a/compose/com.etendoerp.tomcat.yml
+++ b/compose/com.etendoerp.tomcat.yml
@@ -15,4 +15,5 @@ services:
       - ${SOURCE_PATH}:${SOURCE_PATH}
     environment:
       - JPDA_OPTS="-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
+      - CATALINA_OPTS=${TOMCAT_CATALINA_OPTS:-""}
     command: ["catalina.sh", "jpda", "run"]


### PR DESCRIPTION
This pull request introduces a small but important change to the `compose/com.etendoerp.tomcat.yml` file. The change adds support for configuring `CATALINA_OPTS` through an environment variable, enhancing flexibility for customizing Tomcat's runtime options.

* [`compose/com.etendoerp.tomcat.yml`](diffhunk://#diff-993adba91bd7568d69d2cc224e9a1e2c300f4cef51e90442870c038bad254fd6R18): Added a new environment variable `CATALINA_OPTS`, with a default fallback to an empty string, to allow customization of Tomcat's runtime options.