### PR TITLE
Feature ETP-2055: Added default limits for Docker resources

### DIFF
--- a/compose/com.etendoerp.tomcat.yml
+++ b/compose/com.etendoerp.tomcat.yml
@@ -14,17 +14,16 @@ services:
       - ${ATTACH_PATH}:${ATTACH_PATH}
       - ${SOURCE_PATH}:${SOURCE_PATH}
     environment:
-      JAVA_OPTS: -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC
       JPDA_OPTS: "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
       CATALINA_OPTS: ${TOMCAT_CATALINA_OPTS}
     command: ["catalina.sh", "jpda", "run"]
     deploy:
       resources:
         limits:
-          cpus: "1"
-          memory: 512M
+          cpus: "${TOMCAT_CPU_LIMIT:-${BASE_TOMCAT_CPU_LIMIT:-1}}"
+          memory: "${TOMCAT_MEMORY_LIMIT:-${BASE_TOMCAT_MEMORY_LIMIT:-256M}}"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${TOMCAT_PORT}/"]
+      test: ["CMD", "curl", "-f", "http://localhost:${TOMCAT_PORT}/${CONTEXT_NAME}/security/Login"]
       interval: 10s
       timeout: 10s
       retries: 60

--- a/tasks.gradle
+++ b/tasks.gradle
@@ -79,6 +79,20 @@ task "tomcat.env.file" {
         env.withWriterAppend { writer ->
             writer.write("TOMCAT_DEBUG_PORT=${tomcatDebugPort}\n")
         }
+        // Tomcat Resource Limits
+        def TOMCAT_BASE_MEM_MB = getTypedProp("tomcat.base.memory.mb") ?: 256
+        def TOMCAT_BASE_CPU = getTypedProp("tomcat.base.cpu") ?: 1.0
+
+        def tomcatServiceFactors = [
+            TOMCAT: [mem: 2.0, cpu: 1.0] // Default 512Mb - 1 Cpu
+        ]
+        tomcatServiceFactors.each { service, factors ->
+            def memMB = (TOMCAT_BASE_MEM_MB * factors.mem).toInteger()
+            def cpu = ((TOMCAT_BASE_CPU * factors.cpu) as BigDecimal).setScale(3, BigDecimal.ROUND_HALF_UP).toString()
+
+            upsertEnvProperty("BASE_${service}_MEMORY_LIMIT", "${memMB}M")
+            upsertEnvProperty("BASE_${service}_CPU_LIMIT", "${cpu}")
+        }
     }
 }
 


### PR DESCRIPTION
This pull request introduces improvements to how Tomcat resource limits are configured and managed, making them more flexible and easier to adjust through environment variables and build properties. The changes also enhance the health check to ensure the Tomcat service is fully operational before being marked healthy.

Resource limit configuration improvements:

* [`tasks.gradle`](diffhunk://#diff-60fdffcf350ecafe33145fbc861c9a8c1e1928c0eddb028b64fe9c91a0e63c89R82-R95): Added logic to dynamically calculate and set default memory and CPU limits for Tomcat based on configurable base values and service-specific factors, and to write these values to the environment file for use by Docker Compose.
* [`compose/com.etendoerp.tomcat.yml`](diffhunk://#diff-993adba91bd7568d69d2cc224e9a1e2c300f4cef51e90442870c038bad254fd6L17-R26): Updated the Tomcat service's CPU and memory limits to use the new environment variables, allowing for easier customization and consistency across environments.

Health check enhancement:

* [`compose/com.etendoerp.tomcat.yml`](diffhunk://#diff-993adba91bd7568d69d2cc224e9a1e2c300f4cef51e90442870c038bad254fd6L17-R26): Changed the health check endpoint to `/security/Login` within the application context, ensuring the service is only marked healthy when the application is fully up and running.