### PR TITLE
Feature ETP-2052: Added default limits for Docker resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@
 */
 
 group          = "com.etendoerp"
-version        = "2.4.0"
+version        = "2.5.0"
 description    = "Dockerized tomcat deploy"
 ext.artifact   = "tomcat"
 ext.repository = "https://maven.pkg.github.com/etendosoftware/com.etendoerp.platform.extensions"
@@ -52,7 +52,7 @@ sourceSets {
 * Ex: implementation "com.sun.mail:javax.mail:1.6.2"
 */
 dependencies {
-    implementation('com.etendoerp:docker:2.4.0')
+    implementation('com.etendoerp:docker:2.5.0')
     implementation('com.etendoerp.platform:etendo-core:[25.1.0,25.3.0)')
 }
 

--- a/compose/com.etendoerp.tomcat.yml
+++ b/compose/com.etendoerp.tomcat.yml
@@ -4,7 +4,7 @@ services:
     env_file: ".env"
     ports:
       - "${TOMCAT_PORT}:8080"
-      - "${TOMCAT_DEBUG_PORT}:8000"
+      - "${TOMCAT_DEBUG_PORT:-8000}:8000"
     networks:
       - etendo
     extra_hosts:
@@ -14,9 +14,15 @@ services:
       - ${ATTACH_PATH}:${ATTACH_PATH}
       - ${SOURCE_PATH}:${SOURCE_PATH}
     environment:
-      - JPDA_OPTS="-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
-      - CATALINA_OPTS=${TOMCAT_CATALINA_OPTS}
+      JAVA_OPTS: -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC
+      JPDA_OPTS: "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
+      CATALINA_OPTS: ${TOMCAT_CATALINA_OPTS}
     command: ["catalina.sh", "jpda", "run"]
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 512M
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${TOMCAT_PORT}/"]
       interval: 10s

--- a/pipelines/Jenkinsfile
+++ b/pipelines/Jenkinsfile
@@ -257,6 +257,7 @@ spec:
               allow.root=true
               org.gradle.vfs.watch=false
               docker_com.etendoerp.tomcat=true
+              tomcat.base.memory.mb=5120
               tomcat.port=${TOMCAT_PORT}
               org.gradle.jvmargs=-Dfile.encoding=UTF-8
               org.gradle.daemon=false" > gradle.properties

--- a/src-db/database/sourcedata/AD_MODULE.xml
+++ b/src-db/database/sourcedata/AD_MODULE.xml
@@ -6,7 +6,7 @@
 <!--EE80BB65DDE548559AEF6C4AC41E02D0-->  <AD_ORG_ID><![CDATA[0]]></AD_ORG_ID>
 <!--EE80BB65DDE548559AEF6C4AC41E02D0-->  <ISACTIVE><![CDATA[Y]]></ISACTIVE>
 <!--EE80BB65DDE548559AEF6C4AC41E02D0-->  <NAME><![CDATA[Dockerized Tomcat Service]]></NAME>
-<!--EE80BB65DDE548559AEF6C4AC41E02D0-->  <VERSION><![CDATA[2.4.0]]></VERSION>
+<!--EE80BB65DDE548559AEF6C4AC41E02D0-->  <VERSION><![CDATA[2.5.0]]></VERSION>
 <!--EE80BB65DDE548559AEF6C4AC41E02D0-->  <DESCRIPTION><![CDATA[Dockerized Tomcat deploy]]></DESCRIPTION>
 <!--EE80BB65DDE548559AEF6C4AC41E02D0-->  <HELP><![CDATA[This module dockerizes the Tomcat service and is distributed as an Etendo module. It provides a standardized way to run and manage Tomcat within Docker containers, ensuring seamless integration with the Etendo environment.]]></HELP>
 <!--EE80BB65DDE548559AEF6C4AC41E02D0-->  <TYPE><![CDATA[M]]></TYPE>


### PR DESCRIPTION
This pull request introduces improvements to the Tomcat service configuration in the Docker Compose setup and Gradle tasks, focusing on resource limits, environment variable handling, and health checks. The main changes are grouped by theme below.

Resource Limits and Environment Configuration:

* Added CPU and memory resource limits for the Tomcat service in `compose/com.etendoerp.tomcat.yml`, allowing customization via environment variables with sensible defaults and fallback values.
* Updated `tasks.gradle` to dynamically calculate and set base memory and CPU limits for Tomcat, writing these values to the environment file for use in Compose deployments.

Environment Variable Handling:

* Changed the syntax for specifying environment variables in the Compose file from list-style to key-value pairs, improving clarity and compatibility.
* Improved the port mapping for the Tomcat debug port to use a default value if the environment variable is not set, enhancing robustness.

Health Check Improvements:

* Updated the Tomcat service health check to target the login endpoint instead of the root, providing a more accurate indication of service readiness.