### PR TITLE
Feature ETP-3624: Recreate Tomcat container after WAR deploy to clear logs

### DIFF
--- a/tasks.gradle
+++ b/tasks.gradle
@@ -38,6 +38,11 @@ task copyWarToVolume {
         indexFile.write(indexHtmlContent)
 
         executeDockerComposeCommand("cp ${composeRootDir} tomcat:/usr/local/tomcat/webapps/ROOT")
+        try {
+            executeDockerComposeCommand("up -d --force-recreate tomcat")
+        } catch (Exception e) {
+            logger.warn("Could not restart Tomcat container: ${e.message}")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Recreates the Tomcat container after WAR deployment using `--force-recreate` instead of a simple restart
- Clears Docker container logs on each smartbuild deploy
- Handles errors gracefully with a warning if the container is not running

## Test plan
- [ ] Run `smartbuild` with Tomcat running — verify container is recreated and logs are cleared
- [ ] Run `smartbuild` with Tomcat stopped — verify build does not fail, only a warning is logged

ETP-3624